### PR TITLE
Add improved i18n support for language selection

### DIFF
--- a/docs/zh/configurations/README.md
+++ b/docs/zh/configurations/README.md
@@ -353,7 +353,7 @@ enhance: true
 
 本站使用的配置：
 
-```js{6-19}
+```js{6-31}
 module.exports = {
   title: 'Hello, World.',
   description: '📦 🎨 A api-friendly theme for VuePress.',
@@ -373,6 +373,18 @@ module.exports = {
       description: '📦 🎨 一个面向 RESTful API 设计的开箱即用主题。',
     },
   },
+  themeConfig: {
+    locales: {
+      '/': {
+        selectText: 'Languages',
+        label: 'English',
+      },
+      '/zh/': {
+        selectText: '选择语言',
+        label: '简体中文',
+      }
+    }
+  }
 }
 
 ```

--- a/utils.js
+++ b/utils.js
@@ -72,13 +72,23 @@ export function matchLocalePathFromPath(path, locales) {
 export function resolveSidebarItems($page, $site, $localePath) {
   const { themeConfig } = $site
   const sidebars = {}
+  let languageSelectText
 
   if ($site.locales) {
-    sidebars['other-languages'] = {
-      title: 'other languages',
+    let localeTheme = {};
+    
+    if (themeConfig.locales) {
+      localeTheme = themeConfig.locales[$localePath]
+    }
+
+    languageSelectText = localeTheme.selectText || 'other-languages'
+
+    sidebars[languageSelectText] = {
+      title: languageSelectText,
       children: Object.keys($site.locales).map(locale => {
         const item = $site.locales[locale]
         let path
+        let languageTitle = item.text || item.lang
 
         if (item.path === $localePath) {
           path = $page.path // Stay on the current page
@@ -92,8 +102,12 @@ export function resolveSidebarItems($page, $site, $localePath) {
           }
         }
 
+        if(themeConfig.locales && themeConfig.locales[locale] && themeConfig.locales[locale].label) {
+          languageTitle = themeConfig.locales[locale].label
+        }
+
         return {
-          title: item.text || item.lang,
+          title: languageTitle,
           to: path,
           isLangNav: true,
         }


### PR DESCRIPTION
Add language-configurable titles and labels following the Vuepress default theme style: https://github.com/vuejs/vuepress/blob/master/docs/guide/i18n.md